### PR TITLE
Collector configurations enhancements

### DIFF
--- a/docs/onboarding/8_16/operator/onprem_kube_stack_values.yaml
+++ b/docs/onboarding/8_16/operator/onprem_kube_stack_values.yaml
@@ -32,6 +32,8 @@ defaultCRConfig:
         secretKeyRef:
           name: elastic-secret-otel
           key: elastic_api_key
+
+# clusterName: kind
 collectors:
   cluster:
     config:
@@ -108,13 +110,6 @@ collectors:
                 key: app.kubernetes.io/component
                 from: pod
       receivers:
-        k8sobjects:
-          objects:
-            - name: events
-              mode: "watch"
-              group: "events.k8s.io"
-              exclude_watch_type:
-                - "DELETED"
         k8s_cluster:
           auth_type: serviceAccount
           node_conditions_to_report:
@@ -161,6 +156,10 @@ collectors:
             - debug
             - elasticsearch/otel
   daemon:
+    presets:
+      logsCollection:
+        enabled: true
+        storeCheckpoints: true
     hostNetwork: true
     securityContext:
       runAsUser: 0

--- a/docs/onboarding/8_16/operator/onprem_kube_stack_values.yaml
+++ b/docs/onboarding/8_16/operator/onprem_kube_stack_values.yaml
@@ -50,8 +50,10 @@ collectors:
           endpoints:
           - ${env:ELASTIC_ENDPOINT}
           api_key: ${env:ELASTIC_API_KEY}
-          tls:
-            insecure_skip_verify: true
+          logs_dynamic_index:
+            enabled: true
+          # tls:
+          #   insecure_skip_verify: true
           mapping:
             mode: otel
       processors:
@@ -183,18 +185,16 @@ collectors:
           api_key: ${env:ELASTIC_API_KEY}
           logs_dynamic_index:
             enabled: true
-          tls:
-            insecure_skip_verify: true
+          # tls:
+          #   insecure_skip_verify: true
           mapping:
             mode: otel
         elasticsearch/ecs:
           endpoints:
           - ${env:ELASTIC_ENDPOINT}
           api_key: ${env:ELASTIC_API_KEY}
-          logs_dynamic_index:
-            enabled: true
-          tls:
-            insecure_skip_verify: true
+          # tls:
+          #   insecure_skip_verify: true
           mapping:
             mode: ecs
       processors:

--- a/docs/onboarding/8_16/operator/onprem_kube_stack_values.yaml
+++ b/docs/onboarding/8_16/operator/onprem_kube_stack_values.yaml
@@ -40,12 +40,6 @@ collectors:
       exporters:
         debug:
           verbosity: basic
-        elasticsearch/apm:
-          endpoints:
-          - ${env:ELASTIC_ENDPOINT}
-          api_key: ${env:ELASTIC_API_KEY}
-          mapping:
-            mode: ecs
         elasticsearch/otel:
           endpoints:
           - ${env:ELASTIC_ENDPOINT}
@@ -459,10 +453,8 @@ collectors:
               - elasticsearch/otel
           metrics/node/otel:
             receivers:
-              - hostmetrics
               - kubeletstats
             processors:
-              # - elasticinframetrics
               - batch
               - k8sattributes
               - resourcedetection/system

--- a/docs/onboarding/8_16/operator/onprem_kube_stack_values.yaml
+++ b/docs/onboarding/8_16/operator/onprem_kube_stack_values.yaml
@@ -38,16 +38,21 @@ collectors:
       exporters:
         debug:
           verbosity: basic
-        elasticsearch:
+        elasticsearch/apm:
           endpoints:
           - ${env:ELASTIC_ENDPOINT}
           api_key: ${env:ELASTIC_API_KEY}
           mapping:
             mode: ecs
+        elasticsearch/otel:
+          endpoints:
+          - ${env:ELASTIC_ENDPOINT}
+          api_key: ${env:ELASTIC_API_KEY}
+          tls:
+            insecure_skip_verify: true
+          mapping:
+            mode: otel
       processors:
-        elasticinframetrics:
-          add_system_metrics: false
-          add_k8s_metrics: true
         resourcedetection/eks:
           detectors: [env, eks]
           timeout: 15s
@@ -136,9 +141,8 @@ collectors:
           metrics:
             exporters:
             - debug
-            - elasticsearch
+            - elasticsearch/otel
             processors:
-            - elasticinframetrics
             - k8sattributes
             - resourcedetection/eks
             - resourcedetection/gcp
@@ -155,7 +159,7 @@ collectors:
             - resourcedetection/aks
             exporters:
             - debug
-            - elasticsearch
+            - elasticsearch/otel
   daemon:
     hostNetwork: true
     securityContext:
@@ -166,12 +170,32 @@ collectors:
       exporters:
         debug:
           verbosity: basic
-        elasticsearch:
+        elasticsearch/apm:
           endpoints:
           - ${env:ELASTIC_ENDPOINT}
           api_key: ${env:ELASTIC_API_KEY}
           logs_dynamic_index:
             enabled: true
+          mapping:
+            mode: ecs
+        elasticsearch/otel:
+          endpoints:
+          - ${env:ELASTIC_ENDPOINT}
+          api_key: ${env:ELASTIC_API_KEY}
+          logs_dynamic_index:
+            enabled: true
+          tls:
+            insecure_skip_verify: true
+          mapping:
+            mode: otel
+        elasticsearch/ecs:
+          endpoints:
+          - ${env:ELASTIC_ENDPOINT}
+          api_key: ${env:ELASTIC_API_KEY}
+          logs_dynamic_index:
+            enabled: true
+          tls:
+            insecure_skip_verify: true
           mapping:
             mode: ecs
       processors:
@@ -433,8 +457,27 @@ collectors:
               - attributes/k8s_logs_dataset
             exporters:
               - debug
-              - elasticsearch
-          metrics/node:
+              - elasticsearch/otel
+          metrics/node/otel:
+            receivers:
+              - hostmetrics
+              - kubeletstats
+            processors:
+              # - elasticinframetrics
+              - batch
+              - k8sattributes
+              - resourcedetection/system
+              - resourcedetection/eks
+              - resourcedetection/gcp
+              - resourcedetection/aks
+              - resource/k8s
+              - resource/cloud
+              - attributes/dataset
+              - resource/process
+            exporters:
+              - debug
+              - elasticsearch/otel
+          metrics/node/ecs:
             receivers:
               - hostmetrics
               - kubeletstats
@@ -452,7 +495,7 @@ collectors:
               - resource/process
             exporters:
               - debug
-              - elasticsearch
+              - elasticsearch/ecs
           metrics/apm:
             receivers:
               - otlp
@@ -460,7 +503,7 @@ collectors:
               - batch
             exporters:
               - debug
-              - elasticsearch
+              - elasticsearch/apm
           logs/apm:
             receivers:
               - otlp
@@ -468,7 +511,7 @@ collectors:
               - batch
             exporters:
               - debug
-              - elasticsearch
+              - elasticsearch/apm
           traces/apm:
             receivers:
               - otlp
@@ -476,7 +519,7 @@ collectors:
               - batch
             exporters:
               - debug
-              - elasticsearch
+              - elasticsearch/apm
 
 instrumentation:
   enabled: true


### PR DESCRIPTION
In this PR:
1. add comment regarding cluster name: clusterName: kind
2. split elasticsearch exporter to elasticsearch/apm and elasticsearch/otel and elasticsearch/ecs
3. keep commented out for local development:
```
# tls:
#   insecure_skip_verify: true
```
4. remove `elasticinframetrics` for deployment - it is not used
5. Remove `k8sobjects` receiver - it is enabled by default in chart - https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-kube-stack/values.yaml#L529-L530
6. enable in daemonset: `storeCheckpoints: true` 